### PR TITLE
Fix CI build: remove unused HeliumSmall import

### DIFF
--- a/src/pages/projects/helium.jsx
+++ b/src/pages/projects/helium.jsx
@@ -1,7 +1,6 @@
 import React from "react";
 import MxMatters from '../../images/cloudinaryPodcast.jpeg'
 import YahooFinance from '../../images/yahoo_finance.png'
-import HeliumSmall from '../../images/helium-small.jpg'
 import HeliumTransparent from '../../images/helium_small_w_trans.png'
 
 function Helium() {


### PR DESCRIPTION
## What changed
Removes the unused `HeliumSmall` import from `src/pages/projects/helium.jsx`.

## Why
The CRA production build runs with `CI=true`, which promotes ESLint warnings to errors. The `no-unused-vars` warning on this import causes `npm run build` to exit 1, which **fails the Vercel deploy on `main`**. This lint error predates the recent blog PR — it was already on `main` and is currently breaking production deploys.

## Verification
- `CI=true npm run build` now completes successfully.
- Branched off the current `main` (post-merge of #2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)